### PR TITLE
bug/developer-auth-diligence

### DIFF
--- a/lib/providers/authentication_service.dart
+++ b/lib/providers/authentication_service.dart
@@ -50,6 +50,7 @@ class AuthenticationService extends ChangeNotifier {
         }
       }
     } on FirebaseAuthException catch (e) {
+      log(e.message.toString());
       onError("auth/" + e.code);
     }
   }
@@ -75,6 +76,7 @@ class AuthenticationService extends ChangeNotifier {
         onNotVerified();
       }
     } on FirebaseAuthException catch (e) {
+      log(e.message.toString());
       onError("auth/" + e.code);
     }
   }


### PR DESCRIPTION
This (untracked) feature adds more debug capabilities for us to further assess reasons for authentication errors, as we made the frontend errors quite vague for the users.

I will skip the two-man rule for this merge as I am 100% confident that this release is stable.