### PR TITLE
Linum 1.1.0-hotfix.1+9

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -61,6 +61,7 @@
     		<array>
     			<!-- Copied from GoogleService-Info.plist key REVERSED_CLIENT_ID -->
     			<string>com.googleusercontent.apps.704109638785-vdogvirir21e8l356geelo8s4bqagpl4</string>
+    			<string>com.googleusercontent.apps.658687609050-tfva2l6l8fjfpdjvun258ofbkk8ok7tu</string>
     		</array>
     	</dict>
     </array>


### PR DESCRIPTION
Fixes a critical bug when trying to sign in with Google on an Apple device.